### PR TITLE
Make `mentionRegex` stricter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 [![Build][build-badge]][build]
 [![Coverage][coverage-badge]][coverage]
 
-
 ## What is this?
 
-This package is a [unified][] ([remark][]) plugin to convert @ mentions to links: `@wooorm` -> `[**@wooorm**](https://github.com/wooorm)`.
+This package is a [unified][unified-link] ([remark][remark-link]) plugin to convert @ mentions to links: `@wooorm` -> `[**@wooorm**](https://github.com/wooorm)`.
 
 **unified** is a project that transforms content with abstract syntax trees
 (ASTs).
@@ -19,7 +18,9 @@ This is a remark plugin that transforms mdast.
 ```sh
 npm install remark-mentions
 ```
+
 ## Usage
+
 ```js
 import {remark} from 'remark'
 import remarkMentions from 'remark-mentions'
@@ -44,3 +45,7 @@ console.log(String(file))
 [coverage-badge]: https://img.shields.io/codecov/c/github/finnrg/remark-mentions.svg
 
 [coverage]: https://codecov.io/github/finnrg/remark-mentions
+
+[unified-link]: https://github.com/unifiedjs/unified
+
+[remark-link]: https://github.com/remarkjs/remark

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,9 @@
 
 import { findAndReplace } from "mdast-util-find-and-replace";
 
-const userGroup = "[\\da-z][-\\da-z]{0,38}";
+const userGroup = "[\\da-z][-\\da-z_]{0,38}";
 const mentionRegex = new RegExp(
-  "@(" + userGroup + "(?:\\/" + userGroup + ")?)",
+  "(?<!\\S)@(" + userGroup + "(?:\\/" + userGroup + ")?)",
   "gi"
 );
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 /**
  * @typedef {import('mdast').Root} Root
+ * 
+ * @typedef {import('mdast').PhrasingContent} PhrasingContent
  *
  * @typedef {import('mdast-util-find-and-replace').ReplaceFunction} ReplaceFunction
  *
@@ -12,7 +14,7 @@ import { findAndReplace } from "mdast-util-find-and-replace";
 
 const userGroup = "[\\da-z][-\\da-z_]{0,38}";
 const mentionRegex = new RegExp(
-  "(?<!\\S)@(" + userGroup + "(?:\\/" + userGroup + ")?)",
+  "(?:^|\\s)@(" + userGroup + ")",
   "gi"
 );
 
@@ -34,10 +36,26 @@ export default function remarkMentions(
    * @param {string} username
    */
   function replaceMention(value, username) {
-    return {
-      type: "link",
-      url: opts.usernameLink(username),
-      children: [{ type: "strong", children: [{ type: "text", value }] }],
-    };
+    /** @type {PhrasingContent[]} */
+    let whitespace = [];
+    
+    // Separate leading white space
+    if (value.indexOf("@") > 0) {
+      whitespace.push({
+        type: "text",
+        value: value.substring(0, value.indexOf("@")),
+      });
+    }
+
+    return [
+      ...whitespace,
+      {
+        type: "link",
+        url: opts.usernameLink(username),
+        children: [
+          { type: "strong", children: [{ type: "text", value: value.trim() }] }, // Trim the username here
+        ],
+      },
+    ];
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remark-mentions",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remark-mentions",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ import { remark } from "remark";
 import { VFile } from "vfile";
 
 test("remark-mentions", (t) => {
+
   t.equal(typeof remarkMentions, "function", "should be a function");
 
   t.doesNotThrow(() => {

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,8 @@ test("remark-mentions", (t) => {
   t.equal(process("@test"), "[**@test**](/test)\n");
 
   t.equal(process("This is @test"), "This is [**@test**](/test)\n");
+  
+  t.equal(process("https://example.com/@test"), "https://example.com/@test\n");
 
   t.equal(
     process("@test", { usernameLink: (username) => `/Profile/${username}` }),


### PR DESCRIPTION
### Description

This pull request addresses an issue where the existing `mentionRegex` was being matched in unintended contexts, such as emails and URLs containing the "@" symbol. The proposed changes make the `mentionRegex` stricter to prevent false positives and improve the accuracy of mentions in the `remark-mentions` plugin.

### Changes Made

- Modified the `mentionRegex` to make it stricter and prevent unintended matches in emails and URLs containing "@" symbols.
- Added a new test case to validate the correctness of the updated `mentionRegex` implementation.

### Checklist

- [x] Updated `mentionRegex` to be stricter and more accurate.
- [x] Added a new test case to cover the changes.
- [x] Verified that all existing tests pass with the updated regex.
- [x] Ran the test suite locally to ensure compatibility.

This pull request aims to enhance the accuracy of the `remark-mentions` plugin and improve its behaviour when dealing with mentions in various contexts. Please review and provide feedback.

Thank you!